### PR TITLE
VoiceMimicの音声処理とエディタ機能を実装

### DIFF
--- a/Editor/VoiceMimicPresenter.cs
+++ b/Editor/VoiceMimicPresenter.cs
@@ -1,0 +1,60 @@
+using System.Threading.Tasks;
+using VoiceMimic.Model;
+
+namespace VoiceMimic.Presenter
+{
+    /// <summary>
+    /// View からの操作を受け取り Model を呼び出すプレゼンター。
+    /// </summary>
+    public class VoiceMimicPresenter
+    {
+        private readonly VoiceMimicModel model;
+        private readonly IVoiceMimicView view;
+
+        public VoiceMimicPresenter(VoiceMimicModel model, IVoiceMimicView view)
+        {
+            this.model = model;
+            this.view = view;
+        }
+
+        /// <summary>
+        /// 作成ボタン押下処理。
+        /// </summary>
+        public async Task HandleExportAsync()
+        {
+            var snap = view.SnapshotFromView();
+            var validation = model.Validate(snap);
+            if (!validation.isOk)
+            {
+                view.ShowError(validation.messages);
+                return;
+            }
+
+            var ordered = model.OrderSections(snap);
+            var pcm = model.Render(snap, ordered);
+            await view.SaveAsync(pcm);
+        }
+
+        /// <summary>
+        /// 再生ボタン押下処理。
+        /// </summary>
+        public void HandlePlay()
+        {
+            var snap = view.SnapshotFromView();
+            var ordered = model.OrderSections(snap);
+            var pcm = model.Render(snap, ordered);
+            view.Play(pcm);
+        }
+    }
+
+    /// <summary>
+    /// プレゼンターが依存する View のインターフェース。
+    /// </summary>
+    public interface IVoiceMimicView
+    {
+        VoiceMimicModel.SequenceSnapshot SnapshotFromView();
+        void ShowError(System.Collections.Generic.List<VoiceMimicModel.Message> messages);
+        Task SaveAsync(VoiceMimicModel.PcmBuffer pcm);
+        void Play(VoiceMimicModel.PcmBuffer pcm);
+    }
+}

--- a/Editor/VoiceMimicWindow.cs
+++ b/Editor/VoiceMimicWindow.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using VoiceMimic.Model;
+using VoiceMimic.Presenter;
+
+namespace VoiceMimic.View
+{
+    /// <summary>
+    /// VoiceMimic のエディタウィンドウ。
+    /// </summary>
+    public class VoiceMimicWindow : EditorWindow, IVoiceMimicView
+    {
+        private VoiceMimicPresenter presenter;
+        private VoiceMimicModel model;
+        private ObjectField clipField;
+        private IntegerField startField;
+        private IntegerField endField;
+        private FloatField pitchField;
+        private IntegerField centField;
+        private IntegerField fadeField;
+
+        [MenuItem("Tools/VoiceMimic")]
+        public static void ShowWindow()
+        {
+            var window = GetWindow<VoiceMimicWindow>();
+            window.titleContent = new GUIContent("Voice Mimic");
+        }
+
+        private void OnEnable()
+        {
+            model = new VoiceMimicModel();
+            presenter = new VoiceMimicPresenter(model, this);
+            var root = rootVisualElement;
+            root.Add(new Label("Voice Mimic"));
+
+            clipField = new ObjectField("Clip") { objectType = typeof(AudioClip) };
+            startField = new IntegerField("Start Sample");
+            endField = new IntegerField("End Sample");
+            pitchField = new FloatField("Pitch Semitone");
+            centField = new IntegerField("Fine Cent");
+            fadeField = new IntegerField("Fade Ms") { value = 40 };
+
+            root.Add(clipField);
+            root.Add(startField);
+            root.Add(endField);
+            root.Add(pitchField);
+            root.Add(centField);
+            root.Add(fadeField);
+
+            var exportButton = new Button(async () => await presenter.HandleExportAsync()) { text = "書き出し" };
+            root.Add(exportButton);
+            var playButton = new Button(() => presenter.HandlePlay()) { text = "再生" };
+            root.Add(playButton);
+        }
+
+        public VoiceMimicModel.SequenceSnapshot SnapshotFromView()
+        {
+            var section = new VoiceMimicModel.Section
+            {
+                clipRef = clipField.value as AudioClip,
+                startSample = startField.value,
+                endSample = endField.value,
+                pitchSemitone = pitchField.value,
+                fineCent = centField.value,
+                fadeMs = fadeField.value
+            };
+            return new VoiceMimicModel.SequenceSnapshot { sections = new[] { section } };
+        }
+
+        public void ShowError(System.Collections.Generic.List<VoiceMimicModel.Message> messages)
+        {
+            foreach (var m in messages)
+            {
+                Debug.LogError($"{m.category}: {m.text}");
+            }
+        }
+
+        public async Task SaveAsync(VoiceMimicModel.PcmBuffer pcm)
+        {
+            var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            await Task.Run(() => model.ExportWav(pcm, new VoiceMimicModel.ExportTarget { path = path }));
+            AssetDatabase.Refresh();
+        }
+
+        public void Play(VoiceMimicModel.PcmBuffer pcm)
+        {
+            var clip = AudioClip.Create("preview", pcm.samples.Length, 1, pcm.sampleRate, false);
+            clip.SetData(pcm.samples, 0);
+            var audioUtil = typeof(AudioImporter).Assembly.GetType("UnityEditor.AudioUtil");
+            var playMethod = audioUtil.GetMethod("PlayClip", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(AudioClip) }, null);
+            playMethod.Invoke(null, new object[] { clip });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# VoiceMimic
+
+短い音声素材からボイス風シーケンスを生成する Unity エディタ拡張のためのリポジトリ。現在はプロトタイプ段階であり、以下の設計方針に基づいたコードスケルトンを含む。
+
+## 目標
+- 音声区間の切り出しやピッチ変更、正規化を GUI 操作で行えるツールを提供
+- 生成結果のプレビューやファイル書き出しをサポート
+- Undo/Redo や区間単位での試聴により試行錯誤を効率化
+
+## 非目標
+- 大規模オーディオミドルウェアの代替
+- DAW レベルの編集やエフェクト処理
+- ランタイムでのリアルタイム合成
+- Unity エディタ以外での利用
+
+## 構成
+- **Model**: 音声シーケンス合成と検証を担当
+- **Presenter**: View からの入力を受けて Model を呼び出し、結果を View へ橋渡し
+- **View**: UI Toolkit を用いたエディタ画面
+- **ScriptableObject**: 設定保存用の入れ物
+
+## コアアルゴリズム概要
+1. アセット参照の検証とサンプルレート統一
+2. 区間情報の収集と検証
+3. 並び替えとランダム化
+4. ピッチ適用、正規化、クロスフェード、連結
+5. PCM 書き出し
+
+## クラス
+### VoiceMimicModel
+- `Validate` `OrderSections` `Render` `ExportWav` を公開
+- 検証結果は `ValidationResult` として詳細を保持
+
+### VoiceMimicPresenter
+- ボタン押下イベントをハンドリングし、Model を呼び出す
+
+### VoiceMimicWindow
+- `EditorWindow` を継承した View 実装
+- メニュー `Tools/VoiceMimic` から開く
+
+### VoiceMimicAsset
+- 設定保存用 `ScriptableObject`
+
+## 今後の予定
+- 音声処理アルゴリズムの実装
+- UI の詳細な構築と操作性の向上
+- 各種テストの整備
+

--- a/Runtime/VoiceMimicAsset.cs
+++ b/Runtime/VoiceMimicAsset.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using VoiceMimic.Model;
+
+namespace VoiceMimic
+{
+    /// <summary>
+    /// 設定保存用アセット。
+    /// </summary>
+    [CreateAssetMenu(menuName = "VoiceMimic/Asset")]
+    public class VoiceMimicAsset : ScriptableObject
+    {
+        public VoiceMimicModel.Section[] sections;
+        public int? randomSeed;
+        public int sampleRate = 44100;
+        public int version = 1;
+    }
+}

--- a/Runtime/VoiceMimicModel.cs
+++ b/Runtime/VoiceMimicModel.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace VoiceMimic.Model
+{
+    /// <summary>
+    /// 音声シーケンスの合成を行うモデルクラス。
+    /// </summary>
+    public class VoiceMimicModel
+    {
+        /// <summary>
+        /// 入力区間情報。
+        /// </summary>
+        public class Section
+        {
+            public UnityEngine.Object clipRef;
+            public int startSample;
+            public int endSample;
+            public float pitchSemitone;
+            public int fineCent;
+            public int fadeMs;
+        }
+
+        /// <summary>
+        /// スナップショット。
+        /// </summary>
+        public class SequenceSnapshot
+        {
+            public Section[] sections;
+            public int? randomSeed;
+            public int sampleRate = 44100;
+            public bool mono = true;
+        }
+
+        /// <summary>
+        /// 書き出し先。
+        /// </summary>
+        public class ExportTarget
+        {
+            public string path;
+        }
+
+        /// <summary>
+        /// PCMバッファ。
+        /// </summary>
+        public class PcmBuffer
+        {
+            public int sampleRate;
+            public float[] samples = Array.Empty<float>();
+        }
+
+        public enum Severity
+        {
+            Error,
+            Warning
+        }
+
+        public enum Category
+        {
+            Input,
+            Config,
+            IO
+        }
+
+        public class Message
+        {
+            public Severity severity;
+            public Category category;
+            public string path;
+            public string text;
+        }
+
+        public class ValidationResult
+        {
+            public bool isOk;
+            public List<Message> messages = new List<Message>();
+        }
+
+        /// <summary>
+        /// 入力スナップショットの検証を行う。
+        /// </summary>
+        public ValidationResult Validate(SequenceSnapshot snap)
+        {
+            var result = new ValidationResult { isOk = true };
+            if (snap.sections == null || snap.sections.Length == 0)
+            {
+                result.isOk = false;
+                result.messages.Add(new Message
+                {
+                    severity = Severity.Error,
+                    category = Category.Input,
+                    path = "sections",
+                    text = "区間が指定されていません"
+                });
+                return result;
+            }
+
+            for (int i = 0; i < snap.sections.Length; i++)
+            {
+                var s = snap.sections[i];
+                if (s.clipRef == null)
+                {
+                    result.isOk = false;
+                    result.messages.Add(new Message
+                    {
+                        severity = Severity.Error,
+                        category = Category.Input,
+                        path = $"sections[{i}].clipRef",
+                        text = "クリップが設定されていません"
+                    });
+                }
+
+                if (s.startSample > s.endSample)
+                {
+                    result.isOk = false;
+                    result.messages.Add(new Message
+                    {
+                        severity = Severity.Error,
+                        category = Category.Input,
+                        path = $"sections[{i}].startSample",
+                        text = "開始サンプルが終了より大きいです"
+                    });
+                }
+
+                if (Mathf.Abs(s.pitchSemitone) > 12f)
+                {
+                    result.isOk = false;
+                    result.messages.Add(new Message
+                    {
+                        severity = Severity.Error,
+                        category = Category.Input,
+                        path = $"sections[{i}].pitchSemitone",
+                        text = "ピッチは±12以内である必要があります"
+                    });
+                }
+
+                if (s.fadeMs < 0)
+                {
+                    result.isOk = false;
+                    result.messages.Add(new Message
+                    {
+                        severity = Severity.Error,
+                        category = Category.Input,
+                        path = $"sections[{i}].fadeMs",
+                        text = "フェード長が負の値です"
+                    });
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 区間を並び替える。randomSeed が設定されていれば決定的シャッフル。
+        /// </summary>
+        public Section[] OrderSections(SequenceSnapshot snap)
+        {
+            var list = snap.sections.ToList();
+            if (snap.randomSeed.HasValue)
+            {
+                var rng = new System.Random(snap.randomSeed.Value);
+                for (int i = list.Count - 1; i > 0; i--)
+                {
+                    int j = rng.Next(i + 1);
+                    (list[i], list[j]) = (list[j], list[i]);
+                }
+            }
+            return list.ToArray();
+        }
+
+        /// <summary>
+        /// PCMバッファを生成する。
+        /// </summary>
+        public PcmBuffer Render(SequenceSnapshot snap, Section[] ordered)
+        {
+            var output = new List<float>();
+            int lastFade = 0;
+            foreach (var s in ordered)
+            {
+                var clip = s.clipRef as AudioClip;
+                if (clip == null)
+                {
+                    continue;
+                }
+
+                int start = Mathf.Clamp(s.startSample, 0, clip.samples);
+                int end = Mathf.Clamp(s.endSample, 0, clip.samples);
+                int length = Math.Max(0, end - start);
+                var src = new float[length];
+                clip.GetData(src, start);
+
+                float pitchRatio = Mathf.Pow(2f, (s.pitchSemitone + s.fineCent / 100f) / 12f);
+                int resampledLength = Mathf.CeilToInt(length / pitchRatio);
+                var pitched = new float[resampledLength];
+                for (int i = 0; i < resampledLength; i++)
+                {
+                    float pos = i * pitchRatio;
+                    int idx = Mathf.FloorToInt(pos);
+                    float frac = pos - idx;
+                    float a = src[Mathf.Clamp(idx, 0, length - 1)];
+                    float b = src[Mathf.Clamp(idx + 1, 0, length - 1)];
+                    pitched[i] = a + (b - a) * frac;
+                }
+
+                float peak = pitched.Length > 0 ? pitched.Max(x => Mathf.Abs(x)) : 0f;
+                float targetLevel = Mathf.Pow(10f, -3f / 20f);
+                if (peak > 0f)
+                {
+                    float gain = targetLevel / peak;
+                    for (int i = 0; i < pitched.Length; i++)
+                    {
+                        pitched[i] *= gain;
+                    }
+                }
+
+                int fade = Mathf.CeilToInt(s.fadeMs * snap.sampleRate / 1000f);
+                if (output.Count >= fade && fade > 0)
+                {
+                    for (int i = 0; i < fade && i < pitched.Length; i++)
+                    {
+                        int outIndex = output.Count - fade + i;
+                        float t = i / (float)fade;
+                        output[outIndex] = output[outIndex] * (1f - t) + pitched[i] * t;
+                    }
+                    for (int i = fade; i < pitched.Length; i++)
+                    {
+                        output.Add(pitched[i]);
+                    }
+                }
+                else
+                {
+                    output.AddRange(pitched);
+                }
+
+                lastFade = fade;
+            }
+
+            return new PcmBuffer { sampleRate = snap.sampleRate, samples = output.ToArray() };
+        }
+
+        /// <summary>
+        /// WAVファイルとして書き出す。
+        /// </summary>
+        public void ExportWav(PcmBuffer pcm, ExportTarget target)
+        {
+            if (string.IsNullOrEmpty(target.path))
+            {
+                throw new ArgumentException("出力パスが指定されていません", nameof(target));
+            }
+
+            var dir = Path.GetDirectoryName(target.path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            using var fs = new FileStream(target.path, FileMode.Create, FileAccess.Write);
+            using var bw = new BinaryWriter(fs);
+            int dataLength = pcm.samples.Length * 2;
+            int riffLength = 36 + dataLength;
+
+            bw.Write(System.Text.Encoding.ASCII.GetBytes("RIFF"));
+            bw.Write(riffLength);
+            bw.Write(System.Text.Encoding.ASCII.GetBytes("WAVE"));
+
+            bw.Write(System.Text.Encoding.ASCII.GetBytes("fmt "));
+            bw.Write(16);
+            bw.Write((short)1);
+            bw.Write((short)1);
+            bw.Write(pcm.sampleRate);
+            bw.Write(pcm.sampleRate * 2);
+            bw.Write((short)2);
+            bw.Write((short)16);
+
+            bw.Write(System.Text.Encoding.ASCII.GetBytes("data"));
+            bw.Write(dataLength);
+
+            for (int i = 0; i < pcm.samples.Length; i++)
+            {
+                short s = (short)Mathf.Clamp(pcm.samples[i] * 32767f, -32768f, 32767f);
+                bw.Write(s);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## 概要
- モデルにピッチ変換・正規化・クロスフェード・WAV書き出し処理を実装
- エディタウィンドウに入力フィールドと書き出し・プレビュー再生機能を追加

## テスト
- `dotnet --version` : command not found
- `apt-get update` : 403 Forbidden (リポジトリに署名なし)
- `dotnet build` : command not found

------
https://chatgpt.com/codex/tasks/task_e_68a5f3adca7c832ab3abab628de232b6