### PR TITLE
同期処理化と再生エラーハンドリングの改善

### DIFF
--- a/Editor/VoiceMimicPresenter.cs
+++ b/Editor/VoiceMimicPresenter.cs
@@ -1,7 +1,6 @@
-using System.Threading.Tasks;
-using VoiceMimic.Model;
+using System.Collections.Generic;
 
-namespace VoiceMimic.Presenter
+namespace VoiceMimic
 {
     /// <summary>
     /// View からの操作を受け取り Model を呼び出すプレゼンター。
@@ -20,7 +19,7 @@ namespace VoiceMimic.Presenter
         /// <summary>
         /// 作成ボタン押下処理。
         /// </summary>
-        public async Task HandleExportAsync()
+        public void HandleExport()
         {
             var snap = view.SnapshotFromView();
             var validation = model.Validate(snap);
@@ -32,7 +31,7 @@ namespace VoiceMimic.Presenter
 
             var ordered = model.OrderSections(snap);
             var pcm = model.Render(snap, ordered);
-            await view.SaveAsync(pcm);
+            view.Save(pcm);
         }
 
         /// <summary>
@@ -41,6 +40,13 @@ namespace VoiceMimic.Presenter
         public void HandlePlay()
         {
             var snap = view.SnapshotFromView();
+            var validation = model.Validate(snap);
+            if (!validation.isOk)
+            {
+                view.ShowError(validation.messages);
+                return;
+            }
+
             var ordered = model.OrderSections(snap);
             var pcm = model.Render(snap, ordered);
             view.Play(pcm);
@@ -53,8 +59,8 @@ namespace VoiceMimic.Presenter
     public interface IVoiceMimicView
     {
         VoiceMimicModel.SequenceSnapshot SnapshotFromView();
-        void ShowError(System.Collections.Generic.List<VoiceMimicModel.Message> messages);
-        Task SaveAsync(VoiceMimicModel.PcmBuffer pcm);
+        void ShowError(List<VoiceMimicModel.Message> messages);
+        void Save(VoiceMimicModel.PcmBuffer pcm);
         void Play(VoiceMimicModel.PcmBuffer pcm);
     }
 }

--- a/Editor/VoiceMimicWindow.cs
+++ b/Editor/VoiceMimicWindow.cs
@@ -1,12 +1,10 @@
+using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
-using VoiceMimic.Model;
-using VoiceMimic.Presenter;
 
-namespace VoiceMimic.View
+namespace VoiceMimic
 {
     /// <summary>
     /// VoiceMimic のエディタウィンドウ。
@@ -50,7 +48,7 @@ namespace VoiceMimic.View
             root.Add(centField);
             root.Add(fadeField);
 
-            var exportButton = new Button(async () => await presenter.HandleExportAsync()) { text = "書き出し" };
+            var exportButton = new Button(() => presenter.HandleExport()) { text = "書き出し" };
             root.Add(exportButton);
             var playButton = new Button(() => presenter.HandlePlay()) { text = "再生" };
             root.Add(playButton);
@@ -72,13 +70,11 @@ namespace VoiceMimic.View
 
         public void ShowError(System.Collections.Generic.List<VoiceMimicModel.Message> messages)
         {
-            foreach (var m in messages)
-            {
-                Debug.LogError($"{m.category}: {m.text}");
-            }
+            var text = string.Join("\n", messages.Select(m => $"{m.category}: {m.text}"));
+            EditorUtility.DisplayDialog("入力エラー", text, "OK");
         }
 
-        public async Task SaveAsync(VoiceMimicModel.PcmBuffer pcm)
+        public void Save(VoiceMimicModel.PcmBuffer pcm)
         {
             var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
             if (string.IsNullOrEmpty(path))
@@ -86,16 +82,28 @@ namespace VoiceMimic.View
                 return;
             }
 
-            await Task.Run(() => model.ExportWav(pcm, new VoiceMimicModel.ExportTarget { path = path }));
+            model.ExportWav(pcm, new VoiceMimicModel.ExportTarget { path = path });
             AssetDatabase.Refresh();
         }
 
         public void Play(VoiceMimicModel.PcmBuffer pcm)
         {
+            if (pcm == null || pcm.samples == null || pcm.samples.Length == 0)
+            {
+                EditorUtility.DisplayDialog("再生エラー", "再生可能な音声データがありません", "OK");
+                return;
+            }
+
             var clip = AudioClip.Create("preview", pcm.samples.Length, 1, pcm.sampleRate, false);
             clip.SetData(pcm.samples, 0);
             var audioUtil = typeof(AudioImporter).Assembly.GetType("UnityEditor.AudioUtil");
-            var playMethod = audioUtil.GetMethod("PlayClip", BindingFlags.Static | BindingFlags.Public, null, new[] { typeof(AudioClip) }, null);
+            // AudioUtil.PlayClip は internal メソッドのため Public 指定のみでは取得できず null 参照が発生していた
+            var playMethod = audioUtil?.GetMethod("PlayClip", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, new[] { typeof(AudioClip) }, null);
+            if (playMethod == null)
+            {
+                EditorUtility.DisplayDialog("再生エラー", "再生用メソッドが取得できませんでした", "OK");
+                return;
+            }
             playMethod.Invoke(null, new object[] { clip });
         }
     }

--- a/Runtime/VoiceMimicAsset.cs
+++ b/Runtime/VoiceMimicAsset.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using VoiceMimic.Model;
 
 namespace VoiceMimic
 {

--- a/Runtime/VoiceMimicModel.cs
+++ b/Runtime/VoiceMimicModel.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using UnityEngine;
 
-namespace VoiceMimic.Model
+namespace VoiceMimic
 {
     /// <summary>
     /// 音声シーケンスの合成を行うモデルクラス。


### PR DESCRIPTION
## 概要
- 全クラスを共通名前空間 `VoiceMimic` に統一
- 非同期処理を廃止し同期処理へ変更
- 再生前に入力検証を行い不整合はダイアログで通知
- `AudioUtil.PlayClip` 取得失敗による null 参照を修正

## テスト
- `dotnet build` (コマンド未インストールのため実行不可)
- `apt-get update` (リポジトリ 403 により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a5f7eac894832a812be860377b9f8f