### PR TITLE
AudioSource を利用したプレビュー再生への移行

### DIFF
--- a/Editor/AudioPreviewPlayer.cs
+++ b/Editor/AudioPreviewPlayer.cs
@@ -1,0 +1,57 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace VoiceMimic
+{
+    /// <summary>
+    /// AudioSource を用いたプレビュー再生ユーティリティ。
+    /// </summary>
+    internal static class AudioPreviewPlayer
+    {
+        private static GameObject host;
+        private static AudioSource source;
+
+        /// <summary>
+        /// 指定されたクリップを再生する。
+        /// </summary>
+        public static void PlayClip(AudioClip clip)
+        {
+            Stop();
+            host = EditorUtility.CreateGameObjectWithHideFlags(
+                "AudioPreview",
+                HideFlags.HideAndDontSave,
+                typeof(AudioSource));
+            source = host.GetComponent<AudioSource>();
+            source.playOnAwake = false;
+            source.clip = clip;
+            source.Play();
+            EditorApplication.update += Update;
+        }
+
+        private static void Update()
+        {
+            if (source == null || !source.isPlaying)
+            {
+                Stop();
+            }
+        }
+
+        /// <summary>
+        /// 再生中のクリップを停止しオブジェクトを破棄する。
+        /// </summary>
+        public static void Stop()
+        {
+            EditorApplication.update -= Update;
+            if (source != null)
+            {
+                source.Stop();
+            }
+            if (host != null)
+            {
+                Object.DestroyImmediate(host);
+            }
+            source = null;
+            host = null;
+        }
+    }
+}

--- a/Editor/VoiceMimicWindow.cs
+++ b/Editor/VoiceMimicWindow.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -96,15 +95,7 @@ namespace VoiceMimic
 
             var clip = AudioClip.Create("preview", pcm.samples.Length, 1, pcm.sampleRate, false);
             clip.SetData(pcm.samples, 0);
-            var audioUtil = typeof(AudioImporter).Assembly.GetType("UnityEditor.AudioUtil");
-            // AudioUtil.PlayClip は internal メソッドのため Public 指定のみでは取得できず null 参照が発生していた
-            var playMethod = audioUtil?.GetMethod("PlayClip", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, new[] { typeof(AudioClip) }, null);
-            if (playMethod == null)
-            {
-                EditorUtility.DisplayDialog("再生エラー", "再生用メソッドが取得できませんでした", "OK");
-                return;
-            }
-            playMethod.Invoke(null, new object[] { clip });
+            AudioPreviewPlayer.PlayClip(clip);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ### VoiceMimicWindow
 - `EditorWindow` を継承した View 実装
 - メニュー `Tools/VoiceMimic` から開く
+- AudioSource を用いたプレビュー再生を提供
 
 ### VoiceMimicAsset
 - 設定保存用 `ScriptableObject`


### PR DESCRIPTION
## 概要
- AudioUtil のリフレクション呼び出しを廃止
- AudioSource を用いたプレビュー再生ユーティリティを追加
- README を更新

## テスト
- `dotnet build` : command not found (環境に .NET SDK が未導入)

------
https://chatgpt.com/codex/tasks/task_e_68a5fdb9395c832a81a6e264705661d9