### PR TITLE
時間ベースのレンジスライダーによる区間指定

### DIFF
--- a/Editor/VoiceMimicWindow.cs
+++ b/Editor/VoiceMimicWindow.cs
@@ -13,8 +13,9 @@ namespace VoiceMimic
         private VoiceMimicPresenter presenter;
         private VoiceMimicModel model;
         private ObjectField clipField;
-        private IntegerField startField;
-        private IntegerField endField;
+        private FloatField startMsField;
+        private FloatField endMsField;
+        private MinMaxSlider rangeSlider;
         private FloatField pitchField;
         private IntegerField centField;
         private IntegerField fadeField;
@@ -34,18 +35,51 @@ namespace VoiceMimic
             root.Add(new Label("Voice Mimic"));
 
             clipField = new ObjectField("Clip") { objectType = typeof(AudioClip) };
-            startField = new IntegerField("Start Sample");
-            endField = new IntegerField("End Sample");
+            startMsField = new FloatField("開始(ms)");
+            endMsField = new FloatField("終了(ms)");
+            rangeSlider = new MinMaxSlider("範囲(ms)", 0f, 0f, 0f, 0f);
             pitchField = new FloatField("Pitch Semitone");
             centField = new IntegerField("Fine Cent");
             fadeField = new IntegerField("Fade Ms") { value = 40 };
 
             root.Add(clipField);
-            root.Add(startField);
-            root.Add(endField);
+            root.Add(startMsField);
+            root.Add(endMsField);
+            root.Add(rangeSlider);
             root.Add(pitchField);
             root.Add(centField);
             root.Add(fadeField);
+
+            clipField.RegisterValueChangedCallback(e =>
+            {
+                var clip = e.newValue as AudioClip;
+                if (clip != null)
+                {
+                    float lengthMs = clip.length * 1000f;
+                    rangeSlider.lowLimit = 0f;
+                    rangeSlider.highLimit = lengthMs;
+                    rangeSlider.lowValue = 0f;
+                    rangeSlider.highValue = lengthMs;
+                    startMsField.SetValueWithoutNotify(0f);
+                    endMsField.SetValueWithoutNotify(lengthMs);
+                }
+            });
+
+            rangeSlider.RegisterValueChangedCallback(e =>
+            {
+                startMsField.SetValueWithoutNotify(e.newValue.x);
+                endMsField.SetValueWithoutNotify(e.newValue.y);
+            });
+
+            startMsField.RegisterValueChangedCallback(e =>
+            {
+                rangeSlider.lowValue = Mathf.Clamp(e.newValue, rangeSlider.lowLimit, rangeSlider.highValue);
+            });
+
+            endMsField.RegisterValueChangedCallback(e =>
+            {
+                rangeSlider.highValue = Mathf.Clamp(e.newValue, rangeSlider.lowValue, rangeSlider.highLimit);
+            });
 
             var exportButton = new Button(() => presenter.HandleExport()) { text = "書き出し" };
             root.Add(exportButton);
@@ -55,11 +89,16 @@ namespace VoiceMimic
 
         public VoiceMimicModel.SequenceSnapshot SnapshotFromView()
         {
+            var clip = clipField.value as AudioClip;
+            int sampleRate = clip != null ? clip.frequency : 44100;
+            int startSample = Mathf.FloorToInt(startMsField.value / 1000f * sampleRate);
+            int endSample = Mathf.FloorToInt(endMsField.value / 1000f * sampleRate);
+
             var section = new VoiceMimicModel.Section
             {
-                clipRef = clipField.value as AudioClip,
-                startSample = startField.value,
-                endSample = endField.value,
+                clipRef = clip,
+                startSample = startSample,
+                endSample = endSample,
                 pitchSemitone = pitchField.value,
                 fineCent = centField.value,
                 fadeMs = fadeField.value

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - `EditorWindow` を継承した View 実装
 - メニュー `Tools/VoiceMimic` から開く
 - AudioSource を用いたプレビュー再生を提供
+- 開始・終了時間をミリ秒単位で設定できるレンジスライダーを備える
 
 ### VoiceMimicAsset
 - 設定保存用 `ScriptableObject`


### PR DESCRIPTION
## 概要
- 開始・終了サンプル入力をミリ秒単位のレンジスライダーに変更
- クリップ長に応じた範囲上限の自動設定
- README を更新

## テスト
- `dotnet build` (コマンドなしで失敗)
- `apt-get update` (403 Forbidden により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a601ba417c832a8448c6495cfa5eaa