### PR TITLE
GUIに音声ファイルリストと分割ビューを導入

### DIFF
--- a/Editor/VoiceMimicWindow.cs
+++ b/Editor/VoiceMimicWindow.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -10,8 +11,22 @@ namespace VoiceMimic
     /// </summary>
     public class VoiceMimicWindow : EditorWindow, IVoiceMimicView
     {
+        private class SectionData
+        {
+            public AudioClip clip;
+            public float startMs;
+            public float endMs;
+            public float pitchSemitone;
+            public int fineCent;
+            public int fadeMs = 40;
+        }
+
         private VoiceMimicPresenter presenter;
         private VoiceMimicModel model;
+        private readonly List<SectionData> sections = new List<SectionData>();
+        private ListView sectionListView;
+        private int selectedIndex = -1;
+
         private ObjectField clipField;
         private FloatField startMsField;
         private FloatField endMsField;
@@ -32,7 +47,41 @@ namespace VoiceMimic
             model = new VoiceMimicModel();
             presenter = new VoiceMimicPresenter(model, this);
             var root = rootVisualElement;
-            root.Add(new Label("Voice Mimic"));
+            root.Clear();
+
+            var split = new TwoPaneSplitView(0, 250, TwoPaneSplitViewOrientation.Horizontal);
+            root.Add(split);
+
+            var leftPane = new VisualElement();
+            split.Add(leftPane);
+
+            sectionListView = new ListView();
+            sectionListView.itemsSource = sections;
+            sectionListView.selectionType = SelectionType.Single;
+            sectionListView.makeItem = () => new Label();
+            sectionListView.bindItem = (e, i) =>
+            {
+                var label = (Label)e;
+                var data = sections[i];
+                label.text = data.clip != null ? data.clip.name : "未設定";
+            };
+            sectionListView.selectionChanged += _ =>
+            {
+                selectedIndex = sectionListView.selectedIndex;
+                UpdateDetail();
+            };
+            leftPane.Add(sectionListView);
+
+            var addButton = new Button(AddSection) { text = "追加" };
+            leftPane.Add(addButton);
+
+            var playButton = new Button(() => presenter.HandlePlay()) { text = "再生" };
+            leftPane.Add(playButton);
+            var exportButton = new Button(() => presenter.HandleExport()) { text = "書き出し" };
+            leftPane.Add(exportButton);
+
+            var rightPane = new VisualElement();
+            split.Add(rightPane);
 
             clipField = new ObjectField("Clip") { objectType = typeof(AudioClip) };
             startMsField = new FloatField("開始(ms)");
@@ -42,71 +91,166 @@ namespace VoiceMimic
             centField = new IntegerField("Fine Cent");
             fadeField = new IntegerField("Fade Ms") { value = 40 };
 
-            root.Add(clipField);
-            root.Add(startMsField);
-            root.Add(endMsField);
-            root.Add(rangeSlider);
-            root.Add(pitchField);
-            root.Add(centField);
-            root.Add(fadeField);
+            rightPane.Add(clipField);
+            rightPane.Add(startMsField);
+            rightPane.Add(endMsField);
+            rightPane.Add(rangeSlider);
+            rightPane.Add(pitchField);
+            rightPane.Add(centField);
+            rightPane.Add(fadeField);
 
             clipField.RegisterValueChangedCallback(e =>
             {
+                var data = CurrentSection();
                 var clip = e.newValue as AudioClip;
-                if (clip != null)
+                if (data != null)
                 {
-                    float lengthMs = clip.length * 1000f;
-                    rangeSlider.lowLimit = 0f;
-                    rangeSlider.highLimit = lengthMs;
-                    rangeSlider.lowValue = 0f;
-                    rangeSlider.highValue = lengthMs;
-                    startMsField.SetValueWithoutNotify(0f);
-                    endMsField.SetValueWithoutNotify(lengthMs);
+                    data.clip = clip;
+                    if (clip != null)
+                    {
+                        float lengthMs = clip.length * 1000f;
+                        data.startMs = 0f;
+                        data.endMs = lengthMs;
+                        rangeSlider.lowLimit = 0f;
+                        rangeSlider.highLimit = lengthMs;
+                        rangeSlider.SetValueWithoutNotify(new Vector2(0f, lengthMs));
+                        startMsField.SetValueWithoutNotify(0f);
+                        endMsField.SetValueWithoutNotify(lengthMs);
+                    }
                 }
+                sectionListView.RefreshItems();
             });
 
             rangeSlider.RegisterValueChangedCallback(e =>
             {
                 startMsField.SetValueWithoutNotify(e.newValue.x);
                 endMsField.SetValueWithoutNotify(e.newValue.y);
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.startMs = e.newValue.x;
+                    data.endMs = e.newValue.y;
+                }
             });
 
             startMsField.RegisterValueChangedCallback(e =>
             {
-                rangeSlider.lowValue = Mathf.Clamp(e.newValue, rangeSlider.lowLimit, rangeSlider.highValue);
+                float v = Mathf.Clamp(e.newValue, rangeSlider.lowLimit, rangeSlider.highValue);
+                rangeSlider.lowValue = v;
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.startMs = v;
+                }
             });
 
             endMsField.RegisterValueChangedCallback(e =>
             {
-                rangeSlider.highValue = Mathf.Clamp(e.newValue, rangeSlider.lowValue, rangeSlider.highLimit);
+                float v = Mathf.Clamp(e.newValue, rangeSlider.lowValue, rangeSlider.highLimit);
+                rangeSlider.highValue = v;
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.endMs = v;
+                }
             });
 
-            var exportButton = new Button(() => presenter.HandleExport()) { text = "書き出し" };
-            root.Add(exportButton);
-            var playButton = new Button(() => presenter.HandlePlay()) { text = "再生" };
-            root.Add(playButton);
+            pitchField.RegisterValueChangedCallback(e =>
+            {
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.pitchSemitone = e.newValue;
+                }
+            });
+
+            centField.RegisterValueChangedCallback(e =>
+            {
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.fineCent = e.newValue;
+                }
+            });
+
+            fadeField.RegisterValueChangedCallback(e =>
+            {
+                var data = CurrentSection();
+                if (data != null)
+                {
+                    data.fadeMs = e.newValue;
+                }
+            });
+
+            UpdateDetail();
+        }
+
+        private void AddSection()
+        {
+            sections.Add(new SectionData());
+            sectionListView.RefreshItems();
+            sectionListView.selectedIndex = sections.Count - 1;
+        }
+
+        private SectionData CurrentSection()
+        {
+            if (selectedIndex < 0 || selectedIndex >= sections.Count)
+            {
+                return null;
+            }
+            return sections[selectedIndex];
+        }
+
+        private void UpdateDetail()
+        {
+            var data = CurrentSection();
+            bool has = data != null;
+            clipField.SetEnabled(has);
+            startMsField.SetEnabled(has);
+            endMsField.SetEnabled(has);
+            rangeSlider.SetEnabled(has);
+            pitchField.SetEnabled(has);
+            centField.SetEnabled(has);
+            fadeField.SetEnabled(has);
+
+            if (has)
+            {
+                clipField.SetValueWithoutNotify(data.clip);
+                float lengthMs = data.clip != null ? data.clip.length * 1000f : 0f;
+                rangeSlider.lowLimit = 0f;
+                rangeSlider.highLimit = lengthMs;
+                rangeSlider.SetValueWithoutNotify(new Vector2(data.startMs, data.endMs));
+                startMsField.SetValueWithoutNotify(data.startMs);
+                endMsField.SetValueWithoutNotify(data.endMs);
+                pitchField.SetValueWithoutNotify(data.pitchSemitone);
+                centField.SetValueWithoutNotify(data.fineCent);
+                fadeField.SetValueWithoutNotify(data.fadeMs);
+            }
         }
 
         public VoiceMimicModel.SequenceSnapshot SnapshotFromView()
         {
-            var clip = clipField.value as AudioClip;
-            int sampleRate = clip != null ? clip.frequency : 44100;
-            int startSample = Mathf.FloorToInt(startMsField.value / 1000f * sampleRate);
-            int endSample = Mathf.FloorToInt(endMsField.value / 1000f * sampleRate);
-
-            var section = new VoiceMimicModel.Section
+            var list = new List<VoiceMimicModel.Section>();
+            foreach (var s in sections)
             {
-                clipRef = clip,
-                startSample = startSample,
-                endSample = endSample,
-                pitchSemitone = pitchField.value,
-                fineCent = centField.value,
-                fadeMs = fadeField.value
-            };
-            return new VoiceMimicModel.SequenceSnapshot { sections = new[] { section } };
+                var clip = s.clip;
+                int sampleRate = clip != null ? clip.frequency : 44100;
+                int startSample = Mathf.FloorToInt(s.startMs / 1000f * sampleRate);
+                int endSample = Mathf.FloorToInt(s.endMs / 1000f * sampleRate);
+                list.Add(new VoiceMimicModel.Section
+                {
+                    clipRef = clip,
+                    startSample = startSample,
+                    endSample = endSample,
+                    pitchSemitone = s.pitchSemitone,
+                    fineCent = s.fineCent,
+                    fadeMs = s.fadeMs
+                });
+            }
+            return new VoiceMimicModel.SequenceSnapshot { sections = list.ToArray() };
         }
 
-        public void ShowError(System.Collections.Generic.List<VoiceMimicModel.Message> messages)
+        public void ShowError(List<VoiceMimicModel.Message> messages)
         {
             var text = string.Join("\n", messages.Select(m => $"{m.category}: {m.text}"));
             EditorUtility.DisplayDialog("入力エラー", text, "OK");
@@ -139,3 +283,4 @@ namespace VoiceMimic
         }
     }
 }
+


### PR DESCRIPTION
## 概要
- TwoPaneSplitView を用いてウィンドウを左右に分割
- 左側に音声ファイルリスト・再生/書き出しボタンを配置
- 右側で選択音声ファイルの詳細設定を編集可能に変更

## テスト
- `dotnet test` (コマンド未インストール)
- `apt-get update` (403 Forbidden により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a6043cd438832a9eb474b3e17da42e