### PR TITLE
Presenterへ責務を移譲

### DIFF
--- a/Editor/VoiceMimicPresenter.cs
+++ b/Editor/VoiceMimicPresenter.cs
@@ -1,9 +1,16 @@
 namespace VoiceMimic
 {
+    using System;
+    using System.IO;
+    using System.Text;
+    using UnityEditor;
+    using UnityEngine;
+
     public class VoiceMimicPresenter
     {
         private readonly VoiceMimicModel model;
         private readonly VoiceMimicView  view;
+        private const int AssetPickerControlID = 123456;
 
         public VoiceMimicPresenter(VoiceMimicModel model, VoiceMimicView view)
         {
@@ -23,7 +30,12 @@ namespace VoiceMimic
 
             var ordered = model.OrderSections(snap);
             var pcm     = model.Render(snap, ordered);
-            view.Save(pcm);
+
+            var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
+            if (string.IsNullOrEmpty(path)) return;
+
+            ExportWav(pcm, path);
+            AssetDatabase.Refresh();
         }
 
         public void HandlePlay()
@@ -38,7 +50,72 @@ namespace VoiceMimic
 
             var ordered = model.OrderSections(snap);
             var pcm     = model.Render(snap, ordered);
+            if (pcm == null || pcm.samples == null || pcm.samples.Length == 0)
+            {
+                view.ShowNotification(new GUIContent("再生可能な音声データがありません"));
+                return;
+            }
             view.Play(pcm);
+        }
+
+        public void HandleSaveToAsset()
+        {
+            var path = EditorUtility.SaveFilePanelInProject("保存先を選択", "VoiceMimicAsset",
+                "asset", "保存アセットを指定してください");
+            if (string.IsNullOrEmpty(path)) return;
+
+            var snap  = view.SnapshotFromView();
+            var asset = ScriptableObject.CreateInstance<VoiceMimicAsset>();
+            model.WriteToAsset(snap, asset);
+            AssetDatabase.CreateAsset(asset, path);
+            AssetDatabase.SaveAssets();
+            view.ShowNotification(new GUIContent($"保存完了: {path}"));
+        }
+
+        public void HandleLoadFromAsset()
+        {
+            EditorGUIUtility.ShowObjectPicker<VoiceMimicAsset>(null, false, "", AssetPickerControlID);
+        }
+
+        private void ExportWav(VoiceMimicModel.PcmBuffer pcm, string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("出力パスが指定されていません", nameof(path));
+            }
+
+            var dir = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(dir) == false && Directory.Exists(dir) == false)
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
+            using var bw = new BinaryWriter(fs);
+            var dataLength = pcm.samples.Length * 2;
+            var riffLength = 36 + dataLength;
+
+            bw.Write(Encoding.ASCII.GetBytes("RIFF"));
+            bw.Write(riffLength);
+            bw.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+            bw.Write(Encoding.ASCII.GetBytes("fmt "));
+            bw.Write(16);
+            bw.Write((short)1);
+            bw.Write((short)pcm.channels);
+            bw.Write(pcm.sampleRate);
+            bw.Write(pcm.sampleRate * pcm.channels * 2);
+            bw.Write((short)(pcm.channels * 2));
+            bw.Write((short)16);
+
+            bw.Write(Encoding.ASCII.GetBytes("data"));
+            bw.Write(dataLength);
+
+            for (int i = 0; i < pcm.samples.Length; i++)
+            {
+                var s = (short)Mathf.Clamp(pcm.samples[i] * 32767f, -32768f, 32767f);
+                bw.Write(s);
+            }
         }
     }
 }

--- a/Editor/VoiceMimicView.cs
+++ b/Editor/VoiceMimicView.cs
@@ -27,7 +27,6 @@ namespace VoiceMimic
         private const int CentMin  = -50;
         private const int CentMax  = 50;
 
-        private VoiceMimicModel model;
         private VoiceMimicPresenter presenter;
 
         private readonly List<SectionData> sections = new();
@@ -44,9 +43,6 @@ namespace VoiceMimic
         private IntegerField centField;
         private IntegerField fadeField;
 
-        private VoiceMimicAsset selectedAsset;
-        private Label assetNameLabel;
-        private const int AssetPickerControlID = 987321;
 
 
         [MenuItem("Tools/VoiceMimic")]
@@ -58,8 +54,7 @@ namespace VoiceMimic
 
         private void OnEnable()
         {
-            model     = new VoiceMimicModel();
-            presenter = new VoiceMimicPresenter(model, this);
+            presenter = new VoiceMimicPresenter(new VoiceMimicModel(), this);
 
             //UI ToolKit で GUI 作成
             var root  = rootVisualElement;
@@ -79,8 +74,8 @@ namespace VoiceMimic
             split.Add(leftPanel);
 
             var assetBar = new Toolbar();
-            assetBar.Add(new ToolbarButton(() => SaveToAsset())   { text = "設定保存" });
-            assetBar.Add(new ToolbarButton(() => LoadFromAsset()) { text = "設定読込" });
+            assetBar.Add(new ToolbarButton(() => presenter.HandleSaveToAsset()) { text = "設定保存" });
+            assetBar.Add(new ToolbarButton(() => presenter.HandleLoadFromAsset()) { text = "設定読込" });
             leftPanel.Add(assetBar);
 
             //各種ボタン
@@ -310,55 +305,14 @@ namespace VoiceMimic
             return new VoiceMimicModel.SequenceSnapshot { sections = list.ToArray() };
         }
 
-        private void SaveToAsset()
-        {
-#if UNITY_EDITOR
-            var path = EditorUtility.SaveFilePanelInProject("保存先を選択", "VoiceMimicAsset",
-                "asset", "保存アセットを指定してください");
-            if (string.IsNullOrEmpty(path)) return;
-
-            var snap  = SnapshotFromView();
-            var asset = CreateInstance<VoiceMimicAsset>();
-            model.WriteToAsset(snap, asset);
-            AssetDatabase.CreateAsset(asset, path);
-            AssetDatabase.SaveAssets();
-            ShowNotification(new GUIContent($"保存完了: {path}"));
-#endif
-        }
-
-        private void LoadFromAsset()
-        {
-#if UNITY_EDITOR
-            EditorGUIUtility.ShowObjectPicker<VoiceMimicAsset>(null, false, "", 123456);
-#endif
-        }
-
         public void ShowError(List<VoiceMimicModel.Message> messages)
         {
             var text = string.Join("\n", messages.Select(m => $"{m.category}: {m.text}"));
             ShowNotification(new GUIContent(text));
         }
 
-        public void Save(VoiceMimicModel.PcmBuffer pcm)
-        {
-            var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
-            if (string.IsNullOrEmpty(path))
-            {
-                return;
-            }
-
-            model.ExportWav(pcm, path);
-            AssetDatabase.Refresh();
-        }
-
         public void Play(VoiceMimicModel.PcmBuffer pcm)
         {
-            if (pcm == null || pcm.samples == null || pcm.samples.Length == 0)
-            {
-                ShowNotification(new GUIContent("再生可能な音声データがありません"));
-                return;
-            }
-
             int sampleCount = pcm.samples.Length / pcm.channels;
             var clip = AudioClip.Create("preview", sampleCount, pcm.channels, pcm.sampleRate, false);
             clip.SetData(pcm.samples, 0);

--- a/Runtime/VoiceMimicModel.cs
+++ b/Runtime/VoiceMimicModel.cs
@@ -1,9 +1,7 @@
 namespace VoiceMimic
 {
     using System;
-    using System.Text;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using UnityEngine;
 
@@ -225,47 +223,6 @@ namespace VoiceMimic
             }
 
             return new PcmBuffer { sampleRate = snap.sampleRate, channels = channels, samples = interleaved };
-        }
-
-        public void ExportWav(PcmBuffer pcm, string path)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                throw new ArgumentException("出力パスが指定されていません", path);
-            }
-
-            var dir = Path.GetDirectoryName(path);
-            if (string.IsNullOrEmpty(dir) == false && Directory.Exists(dir) == false)
-            {
-                Directory.CreateDirectory(dir);
-            }
-
-            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
-            using var bw = new BinaryWriter(fs);
-            var dataLength = pcm.samples.Length * 2;
-            var riffLength = 36 + dataLength;
-
-            bw.Write(Encoding.ASCII.GetBytes("RIFF"));
-            bw.Write(riffLength);
-            bw.Write(Encoding.ASCII.GetBytes("WAVE"));
-
-            bw.Write(Encoding.ASCII.GetBytes("fmt "));
-            bw.Write(16);
-            bw.Write((short)1);
-            bw.Write((short)pcm.channels);
-            bw.Write(pcm.sampleRate);
-            bw.Write(pcm.sampleRate * pcm.channels * 2);
-            bw.Write((short)(pcm.channels * 2));
-            bw.Write((short)16);
-
-            bw.Write(Encoding.ASCII.GetBytes("data"));
-            bw.Write(dataLength);
-
-            for (int i = 0; i < pcm.samples.Length; i++)
-            {
-                var s = (short)Mathf.Clamp(pcm.samples[i] * 32767f, -32768f, 32767f);
-                bw.Write(s);
-            }
         }
 
         public SequenceSnapshot SnapshotFromAsset(VoiceMimicAsset asset)


### PR DESCRIPTION
## 概要
- ViewとModelの処理をPresenterに集約
- Viewのモデル依存を排除し責務を整理

## テスト
- `dotnet build` (コマンド未存在)
- `apt-get update` (403 Forbidden で失敗)

------
https://chatgpt.com/codex/tasks/task_e_68ab76928eac832a9e3ce3fe91c86be4