### PR TITLE
WavExporter クラスの追加と書き出し処理の整理

### DIFF
--- a/Editor/VoiceMimicPresenter.cs
+++ b/Editor/VoiceMimicPresenter.cs
@@ -1,8 +1,5 @@
 namespace VoiceMimic
 {
-    using System;
-    using System.IO;
-    using System.Text;
     using UnityEditor;
     using UnityEngine;
 
@@ -34,7 +31,7 @@ namespace VoiceMimic
             var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
             if (string.IsNullOrEmpty(path)) return;
 
-            ExportWav(pcm, path);
+            WavExporter.Export(pcm, path);
             AssetDatabase.Refresh();
         }
 
@@ -77,45 +74,5 @@ namespace VoiceMimic
             EditorGUIUtility.ShowObjectPicker<VoiceMimicAsset>(null, false, "", AssetPickerControlID);
         }
 
-        private void ExportWav(VoiceMimicModel.PcmBuffer pcm, string path)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                throw new ArgumentException("出力パスが指定されていません", nameof(path));
-            }
-
-            var dir = Path.GetDirectoryName(path);
-            if (string.IsNullOrEmpty(dir) == false && Directory.Exists(dir) == false)
-            {
-                Directory.CreateDirectory(dir);
-            }
-
-            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
-            using var bw = new BinaryWriter(fs);
-            var dataLength = pcm.samples.Length * 2;
-            var riffLength = 36 + dataLength;
-
-            bw.Write(Encoding.ASCII.GetBytes("RIFF"));
-            bw.Write(riffLength);
-            bw.Write(Encoding.ASCII.GetBytes("WAVE"));
-
-            bw.Write(Encoding.ASCII.GetBytes("fmt "));
-            bw.Write(16);
-            bw.Write((short)1);
-            bw.Write((short)pcm.channels);
-            bw.Write(pcm.sampleRate);
-            bw.Write(pcm.sampleRate * pcm.channels * 2);
-            bw.Write((short)(pcm.channels * 2));
-            bw.Write((short)16);
-
-            bw.Write(Encoding.ASCII.GetBytes("data"));
-            bw.Write(dataLength);
-
-            for (int i = 0; i < pcm.samples.Length; i++)
-            {
-                var s = (short)Mathf.Clamp(pcm.samples[i] * 32767f, -32768f, 32767f);
-                bw.Write(s);
-            }
-        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@
 
 ## クラス
 ### VoiceMimicModel
-- `Validate` `OrderSections` `Render` `ExportWav` を公開
+- `Validate` `OrderSections` `Render` を公開
 - 検証結果は `ValidationResult` として詳細を保持
+
+### WavExporter
+- PCM バッファを WAV ファイルへ書き出す
 
 ### VoiceMimicPresenter
 - ボタン押下イベントをハンドリングし、Model を呼び出す

--- a/Runtime/WavExporter.cs
+++ b/Runtime/WavExporter.cs
@@ -1,0 +1,55 @@
+namespace VoiceMimic
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using UnityEngine;
+
+    /// <summary>
+    /// PCM バッファを WAV 形式のファイルへ書き出すユーティリティ
+    /// </summary>
+    public static class WavExporter
+    {
+        public static void Export(VoiceMimicModel.PcmBuffer pcm, string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("出力パスが指定されていません", nameof(path));
+            }
+
+            var dir = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(dir) == false && Directory.Exists(dir) == false)
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
+            using var bw = new BinaryWriter(fs);
+            var dataLength = pcm.samples.Length * 2;
+            var riffLength = 36 + dataLength;
+
+            bw.Write(Encoding.ASCII.GetBytes("RIFF"));
+            bw.Write(riffLength);
+            bw.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+            bw.Write(Encoding.ASCII.GetBytes("fmt "));
+            bw.Write(16);
+            bw.Write((short)1);
+            bw.Write((short)pcm.channels);
+            bw.Write(pcm.sampleRate);
+            bw.Write(pcm.sampleRate * pcm.channels * 2);
+            bw.Write((short)(pcm.channels * 2));
+            bw.Write((short)16);
+
+            bw.Write(Encoding.ASCII.GetBytes("data"));
+            bw.Write(dataLength);
+
+            for (int i = 0; i < pcm.samples.Length; i++)
+            {
+                var s = (short)Mathf.Clamp(pcm.samples[i] * 32767f, -32768f, 32767f);
+                bw.Write(s);
+            }
+        }
+    }
+}
+

--- a/Runtime/WavExporter.cs.meta
+++ b/Runtime/WavExporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef213d613dbb4d5683b1146575964b0a


### PR DESCRIPTION
## 概要
- WavExporter クラスを追加し PCM 書き出し処理を移植
- VoiceMimicPresenter.HandleExport から WavExporter.Export を呼び出すよう変更
- 旧 ExportWav メソッドを削除し README を更新

## テスト
- `dotnet build` : command not found
- `apt-get update` : 403 Forbidden のため失敗

------
https://chatgpt.com/codex/tasks/task_e_68ab7996f3dc832abc265740d9148b1d