### PR TITLE
View へパス選択と通知処理を集約

### DIFF
--- a/Editor/VoiceMimicPresenter.cs
+++ b/Editor/VoiceMimicPresenter.cs
@@ -7,7 +7,6 @@ namespace VoiceMimic
     {
         private readonly VoiceMimicModel model;
         private readonly VoiceMimicView  view;
-        private const int AssetPickerControlID = 123456;
 
         public VoiceMimicPresenter(VoiceMimicModel model, VoiceMimicView view)
         {
@@ -19,7 +18,7 @@ namespace VoiceMimic
         {
             if (TryBuildPcm(out var pcm) == false) return;
 
-            var path = EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
+            var path = view.PickExportPath();
             if (string.IsNullOrEmpty(path)) return;
 
             WavExporter.Export(pcm, path);
@@ -31,7 +30,7 @@ namespace VoiceMimic
             if (TryBuildPcm(out var pcm) == false) return;
             if (pcm == null || pcm.samples == null || pcm.samples.Length == 0)
             {
-                view.ShowNotification(new GUIContent("再生可能な音声データがありません"));
+                view.Notify("再生可能な音声データがありません");
                 return;
             }
             view.Play(pcm);
@@ -39,8 +38,7 @@ namespace VoiceMimic
 
         public void HandleSaveToAsset()
         {
-            var path = EditorUtility.SaveFilePanelInProject("保存先を選択", "VoiceMimicAsset",
-                "asset", "保存アセットを指定してください");
+            var path = view.PickAssetPath();
             if (string.IsNullOrEmpty(path)) return;
 
             var snap  = view.SnapshotFromView();
@@ -48,12 +46,12 @@ namespace VoiceMimic
             model.WriteToAsset(snap, asset);
             AssetDatabase.CreateAsset(asset, path);
             AssetDatabase.SaveAssets();
-            view.ShowNotification(new GUIContent($"保存完了: {path}"));
+            view.Notify($"保存完了: {path}");
         }
 
         public void HandleLoadFromAsset()
         {
-            EditorGUIUtility.ShowObjectPicker<VoiceMimicAsset>(null, false, "", AssetPickerControlID);
+            view.ShowAssetPicker();
         }
 
         private bool TryBuildPcm(out VoiceMimicModel.PcmBuffer pcm)

--- a/Editor/VoiceMimicView.cs
+++ b/Editor/VoiceMimicView.cs
@@ -26,6 +26,7 @@ namespace VoiceMimic
         private const int PitchMax = 12;
         private const int CentMin  = -50;
         private const int CentMax  = 50;
+        private const int AssetPickerControlID = 123456;
 
         private VoiceMimicPresenter presenter;
 
@@ -303,6 +304,27 @@ namespace VoiceMimic
                 });
             }
             return new VoiceMimicModel.SequenceSnapshot { sections = list.ToArray() };
+        }
+
+        public string PickExportPath()
+        {
+            return EditorUtility.SaveFilePanel("書き出し", "", "output.wav", "wav");
+        }
+
+        public string PickAssetPath()
+        {
+            return EditorUtility.SaveFilePanelInProject(
+                "保存先を選択", "VoiceMimicAsset", "asset", "保存アセットを指定してください");
+        }
+
+        public void ShowAssetPicker()
+        {
+            EditorGUIUtility.ShowObjectPicker<VoiceMimicAsset>(null, false, "", AssetPickerControlID);
+        }
+
+        public void Notify(string message)
+        {
+            ShowNotification(new GUIContent(message));
         }
 
         public void ShowError(List<VoiceMimicModel.Message> messages)


### PR DESCRIPTION
## 概要
- View に書き出し/アセット保存パス選択機能を追加
- Presenter からの UI 操作を View に委譲し責務を分離

## テスト
- `dotnet build` （コマンド不在のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ab7b3fd100832a8adc89edc6ccab1c